### PR TITLE
Prevent node LTS from being updated wrongfully

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -4,6 +4,15 @@
   "schedule": ["before 8am every sunday"],
   "semanticCommits": "enabled",
   "reviewers": ["team:core"],
+  "regexManagers": [
+    {
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": ["FROM node:(?<currentValue>.*?)-alpine\\n"],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node",
+      "versioningTemplate": "node"
+    }
+  ],
   "packageRules": [
     {
       "groupName": "(non-major) devDependencies",
@@ -25,6 +34,11 @@
       "updateTypes": ["major"],
       "automerge": "false",
       "schedule": ["before 7am on Friday"]
+    },
+    {
+      "matchPackageNames": ["node"],
+      "matchManagers": ["dockerfile"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Describe your changes
It prevents the node LTS version from being updated to a wrong version.

## How has this been tested?
Renovate config validator

## Screenshots (if appropriate):

## Checklist before requesting a review
- [x] I have performed a self-review of my code

