### PR TITLE
One PR for each dependency update

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -15,27 +15,6 @@
   ],
   "packageRules": [
     {
-      "groupName": "(non-major) devDependencies",
-      "automerge": "false",
-      "depTypeList": ["devDependencies"],
-      "updateTypes": ["patch", "minor"],
-      "schedule": ["before 7am on Friday"]
-    },
-    {
-      "groupName": "(non-major) dependencies",
-      "depTypeList": ["dependencies"],
-      "updateTypes": ["patch", "minor"],
-      "automerge": "false",
-      "schedule": ["before 7am on Friday"]
-    },
-    {
-      "groupName": "(major) devDependencies & dependencies",
-      "depTypeList": ["dependencies", "devDependencies"],
-      "updateTypes": ["major"],
-      "automerge": "false",
-      "schedule": ["before 7am on Friday"]
-    },
-    {
       "matchPackageNames": ["node"],
       "matchManagers": ["dockerfile"],
       "enabled": false


### PR DESCRIPTION
## Describe your changes

Renovate opens one PR for a group of dependencies (major, minor).
It can lead quickly to ESM/CSJ problems, and more.
This change intends to fix this.

## How has this been tested?
With renovate config validator. It was because we used groupNames that PRs were opened with all dependencies inside.
It should be fixed with this.

## Screenshots (if appropriate):

## Checklist before requesting a review
- [x] I have performed a self-review of my code